### PR TITLE
Add textColor props for iOS datetimepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Allows changing of the timeZone of the date picker. By default it uses the devic
 Allows changing of the textColor of the date picker.
 
 ```js
-<RNDateTimePicker textColor={'red'} />
+<RNDateTimePicker textColor="red" />
 ```
 
 #### `locale` (`optional`, `iOS only`)

--- a/README.md
+++ b/README.md
@@ -230,6 +230,15 @@ Allows changing of the timeZone of the date picker. By default it uses the devic
 <RNDateTimePicker timeZoneOffsetInMinutes={60} />
 ```
 
+#### `textColor` (`optional`, `iOS only`)
+
+Allows changing of the textColor of the date picker.
+
+```js
+// GMT+1
+<RNDateTimePicker textColor={'red'} />
+```
+
 #### `locale` (`optional`, `iOS only`)
 
 Allows changing of the locale of the component. By default it uses the device's locale.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,6 @@ Allows changing of the timeZone of the date picker. By default it uses the devic
 Allows changing of the textColor of the date picker.
 
 ```js
-// GMT+1
 <RNDateTimePicker textColor={'red'} />
 ```
 

--- a/example/App.js
+++ b/example/App.js
@@ -100,6 +100,7 @@ const App = () => {
                   display={display}
                   onChange={onChange}
                   style={styles.iOsPicker}
+                  textColor={'red'}
                 />
               )}
             </View>

--- a/example/App.js
+++ b/example/App.js
@@ -7,6 +7,7 @@ import {
   StatusBar,
   Button,
   Platform,
+  TextInput,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import {Header, Colors} from 'react-native/Libraries/NewAppScreen';
@@ -17,6 +18,7 @@ const App = () => {
   const [date, setDate] = useState(new Date(1598051730000));
   const [mode, setMode] = useState('date');
   const [show, setShow] = useState(false);
+  const [color, setColor] = useState();
   const [display, setDisplay] = useState('default');
 
   const onChange = (event, selectedDate) => {
@@ -44,7 +46,6 @@ const App = () => {
   const showTimepicker = () => {
     showMode('time');
   };
-
   return (
     <>
       <StatusBar barStyle="dark-content" />
@@ -53,7 +54,7 @@ const App = () => {
           contentInsetAdjustmentBehavior="automatic"
           style={styles.scrollView}>
           <Header />
-          {global.HermesInternal == null ? null : (
+          {global.HermesInternal !== null && (
             <View style={styles.engine}>
               <Text style={styles.footer}>Engine: Hermes</Text>
             </View>
@@ -62,6 +63,17 @@ const App = () => {
             <View testID="appRootView" style={styles.container}>
               <View style={styles.header}>
                 <Text style={styles.text}>Example DateTime Picker</Text>
+              </View>
+              <View style={styles.header}>
+                <Text style={{margin: 10, flex: 1}}>text color (iOS only)</Text>
+                <TextInput
+                  value={color}
+                  style={{height: 60, flex: 1}}
+                  onChangeText={text => {
+                    setColor(text.toLowerCase());
+                  }}
+                  placeholder="color"
+                />
               </View>
               <View style={styles.button}>
                 <Button
@@ -89,6 +101,11 @@ const App = () => {
                   {mode === 'time' && moment.utc(date).format('HH:mm')}
                   {mode === 'date' && moment.utc(date).format('MM/DD/YYYY')}
                 </Text>
+                <Button
+                  testID="hidePicker"
+                  onPress={() => setShow(false)}
+                  title="hide picker"
+                />
               </View>
               {show && (
                 <DateTimePicker
@@ -100,7 +117,7 @@ const App = () => {
                   display={display}
                   onChange={onChange}
                   style={styles.iOsPicker}
-                  textColor={'red'}
+                  textColor={color || undefined}
                 />
               )}
             </View>
@@ -137,12 +154,13 @@ const styles = StyleSheet.create({
     backgroundColor: '#F5FCFF',
   },
   header: {
+    justifyContent: 'center',
     alignItems: 'center',
-    marginBottom: 20,
+    flexDirection: 'row',
   },
   button: {
     alignItems: 'center',
-    marginBottom: 20,
+    marginBottom: 10,
   },
   text: {
     fontSize: 20,

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,77 +11,77 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - React (0.60.5):
-    - React-Core (= 0.60.5)
-    - React-DevSupport (= 0.60.5)
-    - React-RCTActionSheet (= 0.60.5)
-    - React-RCTAnimation (= 0.60.5)
-    - React-RCTBlob (= 0.60.5)
-    - React-RCTImage (= 0.60.5)
-    - React-RCTLinking (= 0.60.5)
-    - React-RCTNetwork (= 0.60.5)
-    - React-RCTSettings (= 0.60.5)
-    - React-RCTText (= 0.60.5)
-    - React-RCTVibration (= 0.60.5)
-    - React-RCTWebSocket (= 0.60.5)
-  - React-Core (0.60.5):
+  - React (0.60.6):
+    - React-Core (= 0.60.6)
+    - React-DevSupport (= 0.60.6)
+    - React-RCTActionSheet (= 0.60.6)
+    - React-RCTAnimation (= 0.60.6)
+    - React-RCTBlob (= 0.60.6)
+    - React-RCTImage (= 0.60.6)
+    - React-RCTLinking (= 0.60.6)
+    - React-RCTNetwork (= 0.60.6)
+    - React-RCTSettings (= 0.60.6)
+    - React-RCTText (= 0.60.6)
+    - React-RCTVibration (= 0.60.6)
+    - React-RCTWebSocket (= 0.60.6)
+  - React-Core (0.60.6):
     - Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.60.5)
-    - React-jsiexecutor (= 0.60.5)
-    - yoga (= 0.60.5.React)
-  - React-cxxreact (0.60.5):
+    - React-cxxreact (= 0.60.6)
+    - React-jsiexecutor (= 0.60.6)
+    - yoga (= 0.60.6.React)
+  - React-cxxreact (0.60.6):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-jsinspector (= 0.60.5)
-  - React-DevSupport (0.60.5):
-    - React-Core (= 0.60.5)
-    - React-RCTWebSocket (= 0.60.5)
-  - React-jsi (0.60.5):
+    - React-jsinspector (= 0.60.6)
+  - React-DevSupport (0.60.6):
+    - React-Core (= 0.60.6)
+    - React-RCTWebSocket (= 0.60.6)
+  - React-jsi (0.60.6):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-jsi/Default (= 0.60.5)
-  - React-jsi/Default (0.60.5):
+    - React-jsi/Default (= 0.60.6)
+  - React-jsi/Default (0.60.6):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-  - React-jsiexecutor (0.60.5):
+  - React-jsiexecutor (0.60.6):
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-cxxreact (= 0.60.5)
-    - React-jsi (= 0.60.5)
-  - React-jsinspector (0.60.5)
-  - React-RCTActionSheet (0.60.5):
-    - React-Core (= 0.60.5)
-  - React-RCTAnimation (0.60.5):
-    - React-Core (= 0.60.5)
-  - React-RCTBlob (0.60.5):
-    - React-Core (= 0.60.5)
-    - React-RCTNetwork (= 0.60.5)
-    - React-RCTWebSocket (= 0.60.5)
-  - React-RCTImage (0.60.5):
-    - React-Core (= 0.60.5)
-    - React-RCTNetwork (= 0.60.5)
-  - React-RCTLinking (0.60.5):
-    - React-Core (= 0.60.5)
-  - React-RCTNetwork (0.60.5):
-    - React-Core (= 0.60.5)
-  - React-RCTSettings (0.60.5):
-    - React-Core (= 0.60.5)
-  - React-RCTText (0.60.5):
-    - React-Core (= 0.60.5)
-  - React-RCTVibration (0.60.5):
-    - React-Core (= 0.60.5)
-  - React-RCTWebSocket (0.60.5):
-    - React-Core (= 0.60.5)
-  - RNDateTimePicker (2.1.2):
+    - React-cxxreact (= 0.60.6)
+    - React-jsi (= 0.60.6)
+  - React-jsinspector (0.60.6)
+  - React-RCTActionSheet (0.60.6):
+    - React-Core (= 0.60.6)
+  - React-RCTAnimation (0.60.6):
+    - React-Core (= 0.60.6)
+  - React-RCTBlob (0.60.6):
+    - React-Core (= 0.60.6)
+    - React-RCTNetwork (= 0.60.6)
+    - React-RCTWebSocket (= 0.60.6)
+  - React-RCTImage (0.60.6):
+    - React-Core (= 0.60.6)
+    - React-RCTNetwork (= 0.60.6)
+  - React-RCTLinking (0.60.6):
+    - React-Core (= 0.60.6)
+  - React-RCTNetwork (0.60.6):
+    - React-Core (= 0.60.6)
+  - React-RCTSettings (0.60.6):
+    - React-Core (= 0.60.6)
+  - React-RCTText (0.60.6):
+    - React-Core (= 0.60.6)
+  - React-RCTVibration (0.60.6):
+    - React-Core (= 0.60.6)
+  - React-RCTWebSocket (0.60.6):
+    - React-Core (= 0.60.6)
+  - RNDateTimePicker (2.2.3):
     - React
-  - yoga (0.60.5.React)
+  - yoga (0.60.6.React)
 
 DEPENDENCIES:
   - DoubleConversion (from `../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
@@ -162,26 +162,26 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  React: 53c53c4d99097af47cf60594b8706b4e3321e722
-  React-Core: ba421f6b4f4cbe2fb17c0b6fc675f87622e78a64
-  React-cxxreact: 8384287780c4999351ad9b6e7a149d9ed10a2395
-  React-DevSupport: 197fb409737cff2c4f9986e77c220d7452cb9f9f
-  React-jsi: 4d8c9efb6312a9725b18d6fc818ffc103f60fec2
-  React-jsiexecutor: 90ad2f9db09513fc763bc757fdc3c4ff8bde2a30
-  React-jsinspector: e08662d1bf5b129a3d556eb9ea343a3f40353ae4
-  React-RCTActionSheet: b0f1ea83f4bf75fb966eae9bfc47b78c8d3efd90
-  React-RCTAnimation: 359ba1b5690b1e87cc173558a78e82d35919333e
-  React-RCTBlob: 5e2b55f76e9a1c7ae52b826923502ddc3238df24
-  React-RCTImage: f5f1c50922164e89bdda67bcd0153952a5cfe719
-  React-RCTLinking: d0ecbd791e9ddddc41fa1f66b0255de90e8ee1e9
-  React-RCTNetwork: e26946300b0ab7bb6c4a6348090e93fa21f33a9d
-  React-RCTSettings: d0d37cb521b7470c998595a44f05847777cc3f42
-  React-RCTText: b074d89033583d4f2eb5faf7ea2db3a13c7553a2
-  React-RCTVibration: 2105b2e0e2b66a6408fc69a46c8a7fb5b2fdade0
-  React-RCTWebSocket: cd932a16b7214898b6b7f788c8bddb3637246ac4
-  RNDateTimePicker: abaac403abbc72e127bf678d65e0abd312e4b6a7
-  yoga: 312528f5bbbba37b4dcea5ef00e8b4033fdd9411
+  React: 68e7f8dfc27729eade18423072a143120f2f32ab
+  React-Core: fc9dace551f6c8c1007dd2d3cb1bc10c90a01d3e
+  React-cxxreact: abe59014fce932d41a08bf1aa5dcad9ca8f0a2c5
+  React-DevSupport: b0da2fd9ad4ffb25561bf2a328ab84f78f871bdd
+  React-jsi: 1a4248256b96fa453536a8dafe11b784e24e789d
+  React-jsiexecutor: 2279e559b921d02dfc6253ebef3dcb3a9dc6c07e
+  React-jsinspector: a58b86545a0185f69768e78ac96ca9fe43fa3694
+  React-RCTActionSheet: 49f6a67a7efa6688f637296383d453b97ef13645
+  React-RCTAnimation: e8047438b2927ebbe630bbf600c7309374075df3
+  React-RCTBlob: 2c4b28daca5b3e6e356706d8e0c7436a0e8ef492
+  React-RCTImage: 273501f0529775962551613259c20ccdf1a87cd2
+  React-RCTLinking: 76c88b3cc98657915a2ba2f20d208e44d0530a43
+  React-RCTNetwork: 77c11e672ccdcc33da5d047705f100b016497b15
+  React-RCTSettings: f727c25ad26a8a9bd7272a8ba93781bd1f53952a
+  React-RCTText: d91537e29e38dc69cf09cbca0875cf5dc7402da6
+  React-RCTVibration: 7655d72dfb919dd6d8e135ca108a5a2bd9fcd7b4
+  React-RCTWebSocket: 7cd2c8d0f8ddd680dc76404defba7ab1f56b83af
+  RNDateTimePicker: bc947b8ee2d74cf940df1915bf1dd3359f375c9f
+  yoga: 5079887aa3e4c62142d6bcee493022643ee4d730
 
-PODFILE CHECKSUM: 9d4fcddc60c204830591affd670263270598f3c1
+PODFILE CHECKSUM: 02bf92e8a7d12d3f6dd494033c0b149461530448
 
 COCOAPODS: 1.8.4

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,77 +11,77 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - React (0.60.6):
-    - React-Core (= 0.60.6)
-    - React-DevSupport (= 0.60.6)
-    - React-RCTActionSheet (= 0.60.6)
-    - React-RCTAnimation (= 0.60.6)
-    - React-RCTBlob (= 0.60.6)
-    - React-RCTImage (= 0.60.6)
-    - React-RCTLinking (= 0.60.6)
-    - React-RCTNetwork (= 0.60.6)
-    - React-RCTSettings (= 0.60.6)
-    - React-RCTText (= 0.60.6)
-    - React-RCTVibration (= 0.60.6)
-    - React-RCTWebSocket (= 0.60.6)
-  - React-Core (0.60.6):
+  - React (0.60.5):
+    - React-Core (= 0.60.5)
+    - React-DevSupport (= 0.60.5)
+    - React-RCTActionSheet (= 0.60.5)
+    - React-RCTAnimation (= 0.60.5)
+    - React-RCTBlob (= 0.60.5)
+    - React-RCTImage (= 0.60.5)
+    - React-RCTLinking (= 0.60.5)
+    - React-RCTNetwork (= 0.60.5)
+    - React-RCTSettings (= 0.60.5)
+    - React-RCTText (= 0.60.5)
+    - React-RCTVibration (= 0.60.5)
+    - React-RCTWebSocket (= 0.60.5)
+  - React-Core (0.60.5):
     - Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.60.6)
-    - React-jsiexecutor (= 0.60.6)
-    - yoga (= 0.60.6.React)
-  - React-cxxreact (0.60.6):
+    - React-cxxreact (= 0.60.5)
+    - React-jsiexecutor (= 0.60.5)
+    - yoga (= 0.60.5.React)
+  - React-cxxreact (0.60.5):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-jsinspector (= 0.60.6)
-  - React-DevSupport (0.60.6):
-    - React-Core (= 0.60.6)
-    - React-RCTWebSocket (= 0.60.6)
-  - React-jsi (0.60.6):
+    - React-jsinspector (= 0.60.5)
+  - React-DevSupport (0.60.5):
+    - React-Core (= 0.60.5)
+    - React-RCTWebSocket (= 0.60.5)
+  - React-jsi (0.60.5):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-jsi/Default (= 0.60.6)
-  - React-jsi/Default (0.60.6):
+    - React-jsi/Default (= 0.60.5)
+  - React-jsi/Default (0.60.5):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-  - React-jsiexecutor (0.60.6):
+  - React-jsiexecutor (0.60.5):
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-cxxreact (= 0.60.6)
-    - React-jsi (= 0.60.6)
-  - React-jsinspector (0.60.6)
-  - React-RCTActionSheet (0.60.6):
-    - React-Core (= 0.60.6)
-  - React-RCTAnimation (0.60.6):
-    - React-Core (= 0.60.6)
-  - React-RCTBlob (0.60.6):
-    - React-Core (= 0.60.6)
-    - React-RCTNetwork (= 0.60.6)
-    - React-RCTWebSocket (= 0.60.6)
-  - React-RCTImage (0.60.6):
-    - React-Core (= 0.60.6)
-    - React-RCTNetwork (= 0.60.6)
-  - React-RCTLinking (0.60.6):
-    - React-Core (= 0.60.6)
-  - React-RCTNetwork (0.60.6):
-    - React-Core (= 0.60.6)
-  - React-RCTSettings (0.60.6):
-    - React-Core (= 0.60.6)
-  - React-RCTText (0.60.6):
-    - React-Core (= 0.60.6)
-  - React-RCTVibration (0.60.6):
-    - React-Core (= 0.60.6)
-  - React-RCTWebSocket (0.60.6):
-    - React-Core (= 0.60.6)
-  - RNDateTimePicker (2.2.3):
+    - React-cxxreact (= 0.60.5)
+    - React-jsi (= 0.60.5)
+  - React-jsinspector (0.60.5)
+  - React-RCTActionSheet (0.60.5):
+    - React-Core (= 0.60.5)
+  - React-RCTAnimation (0.60.5):
+    - React-Core (= 0.60.5)
+  - React-RCTBlob (0.60.5):
+    - React-Core (= 0.60.5)
+    - React-RCTNetwork (= 0.60.5)
+    - React-RCTWebSocket (= 0.60.5)
+  - React-RCTImage (0.60.5):
+    - React-Core (= 0.60.5)
+    - React-RCTNetwork (= 0.60.5)
+  - React-RCTLinking (0.60.5):
+    - React-Core (= 0.60.5)
+  - React-RCTNetwork (0.60.5):
+    - React-Core (= 0.60.5)
+  - React-RCTSettings (0.60.5):
+    - React-Core (= 0.60.5)
+  - React-RCTText (0.60.5):
+    - React-Core (= 0.60.5)
+  - React-RCTVibration (0.60.5):
+    - React-Core (= 0.60.5)
+  - React-RCTWebSocket (0.60.5):
+    - React-Core (= 0.60.5)
+  - RNDateTimePicker (2.1.2):
     - React
-  - yoga (0.60.6.React)
+  - yoga (0.60.5.React)
 
 DEPENDENCIES:
   - DoubleConversion (from `../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
@@ -162,26 +162,26 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  React: 68e7f8dfc27729eade18423072a143120f2f32ab
-  React-Core: fc9dace551f6c8c1007dd2d3cb1bc10c90a01d3e
-  React-cxxreact: abe59014fce932d41a08bf1aa5dcad9ca8f0a2c5
-  React-DevSupport: b0da2fd9ad4ffb25561bf2a328ab84f78f871bdd
-  React-jsi: 1a4248256b96fa453536a8dafe11b784e24e789d
-  React-jsiexecutor: 2279e559b921d02dfc6253ebef3dcb3a9dc6c07e
-  React-jsinspector: a58b86545a0185f69768e78ac96ca9fe43fa3694
-  React-RCTActionSheet: 49f6a67a7efa6688f637296383d453b97ef13645
-  React-RCTAnimation: e8047438b2927ebbe630bbf600c7309374075df3
-  React-RCTBlob: 2c4b28daca5b3e6e356706d8e0c7436a0e8ef492
-  React-RCTImage: 273501f0529775962551613259c20ccdf1a87cd2
-  React-RCTLinking: 76c88b3cc98657915a2ba2f20d208e44d0530a43
-  React-RCTNetwork: 77c11e672ccdcc33da5d047705f100b016497b15
-  React-RCTSettings: f727c25ad26a8a9bd7272a8ba93781bd1f53952a
-  React-RCTText: d91537e29e38dc69cf09cbca0875cf5dc7402da6
-  React-RCTVibration: 7655d72dfb919dd6d8e135ca108a5a2bd9fcd7b4
-  React-RCTWebSocket: 7cd2c8d0f8ddd680dc76404defba7ab1f56b83af
-  RNDateTimePicker: bc947b8ee2d74cf940df1915bf1dd3359f375c9f
-  yoga: 5079887aa3e4c62142d6bcee493022643ee4d730
+  React: 53c53c4d99097af47cf60594b8706b4e3321e722
+  React-Core: ba421f6b4f4cbe2fb17c0b6fc675f87622e78a64
+  React-cxxreact: 8384287780c4999351ad9b6e7a149d9ed10a2395
+  React-DevSupport: 197fb409737cff2c4f9986e77c220d7452cb9f9f
+  React-jsi: 4d8c9efb6312a9725b18d6fc818ffc103f60fec2
+  React-jsiexecutor: 90ad2f9db09513fc763bc757fdc3c4ff8bde2a30
+  React-jsinspector: e08662d1bf5b129a3d556eb9ea343a3f40353ae4
+  React-RCTActionSheet: b0f1ea83f4bf75fb966eae9bfc47b78c8d3efd90
+  React-RCTAnimation: 359ba1b5690b1e87cc173558a78e82d35919333e
+  React-RCTBlob: 5e2b55f76e9a1c7ae52b826923502ddc3238df24
+  React-RCTImage: f5f1c50922164e89bdda67bcd0153952a5cfe719
+  React-RCTLinking: d0ecbd791e9ddddc41fa1f66b0255de90e8ee1e9
+  React-RCTNetwork: e26946300b0ab7bb6c4a6348090e93fa21f33a9d
+  React-RCTSettings: d0d37cb521b7470c998595a44f05847777cc3f42
+  React-RCTText: b074d89033583d4f2eb5faf7ea2db3a13c7553a2
+  React-RCTVibration: 2105b2e0e2b66a6408fc69a46c8a7fb5b2fdade0
+  React-RCTWebSocket: cd932a16b7214898b6b7f788c8bddb3637246ac4
+  RNDateTimePicker: abaac403abbc72e127bf678d65e0abd312e4b6a7
+  yoga: 312528f5bbbba37b4dcea5ef00e8b4033fdd9411
 
-PODFILE CHECKSUM: 02bf92e8a7d12d3f6dd494033c0b149461530448
+PODFILE CHECKSUM: 9d4fcddc60c204830591affd670263270598f3c1
 
 COCOAPODS: 1.8.4

--- a/ios/RNDateTimePickerManager.m
+++ b/ios/RNDateTimePickerManager.m
@@ -40,12 +40,21 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_REMAP_VIEW_PROPERTY(mode, datePickerMode, UIDatePickerMode)
 RCT_REMAP_VIEW_PROPERTY(timeZoneOffsetInMinutes, timeZone, NSTimeZone)
 
-RCT_CUSTOM_VIEW_PROPERTY(textColor, NSNumber, RNDateTimePicker)
+RCT_CUSTOM_VIEW_PROPERTY(textColor, UIColor, RNDateTimePicker)
 {
-  if (!json) return;
-    
-  [view setValue:[RCTConvert UIColor:json] forKey:@"textColor"];
-  [view setValue:@NO forKey:@"highlightsToday"];
+  if (json) {
+    [view setValue:[RCTConvert UIColor:json] forKey:@"textColor"];
+    [view setValue:@(NO) forKey:@"highlightsToday"];
+  } else {
+    UIColor* defaultColor;
+    if (@available(iOS 13.0, *)) {
+        defaultColor = [UIColor labelColor];
+    } else {
+        defaultColor = [UIColor blackColor];
+    }
+    [view setValue:defaultColor forKey:@"textColor"];
+    [view setValue:@(YES) forKey:@"highlightsToday"];
+  }
 }
 
 @end

--- a/ios/RNDateTimePickerManager.m
+++ b/ios/RNDateTimePickerManager.m
@@ -40,8 +40,10 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_REMAP_VIEW_PROPERTY(mode, datePickerMode, UIDatePickerMode)
 RCT_REMAP_VIEW_PROPERTY(timeZoneOffsetInMinutes, timeZone, NSTimeZone)
 
-RCT_CUSTOM_VIEW_PROPERTY(textColor, UIColor, RNDateTimePicker)
+RCT_CUSTOM_VIEW_PROPERTY(textColor, NSNumber, RNDateTimePicker)
 {
+  if (!json) return;
+    
   [view setValue:[RCTConvert UIColor:json] forKey:@"textColor"];
   [view setValue:@NO forKey:@"highlightsToday"];
 }

--- a/ios/RNDateTimePickerManager.m
+++ b/ios/RNDateTimePickerManager.m
@@ -40,4 +40,10 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_REMAP_VIEW_PROPERTY(mode, datePickerMode, UIDatePickerMode)
 RCT_REMAP_VIEW_PROPERTY(timeZoneOffsetInMinutes, timeZone, NSTimeZone)
 
+RCT_CUSTOM_VIEW_PROPERTY(textColor, UIColor, RNDateTimePicker)
+{
+  [view setValue:[RCTConvert UIColor:json] forKey:@"textColor"];
+  [view setValue:@NO forKey:@"highlightsToday"];
+}
+
 @end

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -9,7 +9,7 @@
  * @format
  * @flow strict-local
  */
-import {StyleSheet, processColor} from 'react-native';
+import {StyleSheet} from 'react-native';
 import RNDateTimePicker from './picker';
 import {toMilliseconds} from './utils';
 import {MODE_DATE} from './constants';
@@ -69,16 +69,10 @@ export default class Picker extends React.Component<IOSNativeProps> {
       mode,
       minuteInterval,
       timeZoneOffsetInMinutes,
-      textColor: _textColor,
+      textColor,
     } = this.props;
 
     invariant(value, 'A date or time should be specified as `value`.');
-
-    const textColor = processColor(_textColor);
-    invariant(
-      textColor == null || typeof textColor === 'number',
-      'Unexpected color given for props.textColor',
-    );
 
     const dates: DatePickerOptions = {value, maximumDate, minimumDate};
     toMilliseconds(dates, 'value', 'minimumDate', 'maximumDate');

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -9,7 +9,7 @@
  * @format
  * @flow strict-local
  */
-import {StyleSheet} from 'react-native';
+import {StyleSheet, processColor} from 'react-native';
 import RNDateTimePicker from './picker';
 import {toMilliseconds} from './utils';
 import {MODE_DATE} from './constants';
@@ -69,10 +69,16 @@ export default class Picker extends React.Component<IOSNativeProps> {
       mode,
       minuteInterval,
       timeZoneOffsetInMinutes,
-      textColor,
+      textColor: _textColor,
     } = this.props;
 
     invariant(value, 'A date or time should be specified as `value`.');
+
+    const textColor = processColor(_textColor);
+    invariant(
+      textColor == null || typeof textColor === 'number',
+      'Unexpected color given for props.textColor',
+    );
 
     const dates: DatePickerOptions = {value, maximumDate, minimumDate};
     toMilliseconds(dates, 'value', 'minimumDate', 'maximumDate');

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -69,6 +69,7 @@ export default class Picker extends React.Component<IOSNativeProps> {
       mode,
       minuteInterval,
       timeZoneOffsetInMinutes,
+      textColor,
     } = this.props;
 
     invariant(value, 'A date or time should be specified as `value`.');
@@ -89,6 +90,7 @@ export default class Picker extends React.Component<IOSNativeProps> {
         minuteInterval={minuteInterval}
         timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
         onChange={this._onChange}
+        textColor={textColor}
         onStartShouldSetResponder={() => true}
         onResponderTerminationRequest={() => false}
       />

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
 import { FC, Ref, SyntheticEvent } from 'react'
 import { NativeComponent, ViewProps } from 'react-native'
+import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 
 type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';
 type AndroidMode = 'date' | 'time';
@@ -87,6 +88,11 @@ export type IOSNativeProps = Readonly<BaseProps & {
    * instance, to show times in Pacific Standard Time, pass -7 * 60.
    */
   timeZoneOffsetInMinutes?: number,
+
+  /**
+   * The date picker text color.
+   */
+  textColor?: ColorValue,
 }>;
 
 export type AndroidNativeProps = Readonly<BaseProps & DateOptions & TimeOptions & {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -92,7 +92,7 @@ export type IOSNativeProps = Readonly<BaseProps & {
   /**
    * The date picker text color.
    */
-  textColor?: ColorValue,
+  textColor?: ?ColorValue,
 }>;
 
 export type AndroidNativeProps = Readonly<BaseProps & DateOptions & TimeOptions & {

--- a/src/types.js
+++ b/src/types.js
@@ -7,6 +7,7 @@ import type {SyntheticEvent} from 'CoreEventTypes';
 import type {NativeComponent} from 'ReactNative';
 import type {ViewProps} from 'ViewPropTypes';
 import type {ElementRef} from 'react';
+import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 
 type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';
 type AndroidMode = 'date' | 'time';
@@ -99,6 +100,11 @@ export type IOSNativeProps = $ReadOnly<{|
    * instance, to show times in Pacific Standard Time, pass -7 * 60.
    */
   timeZoneOffsetInMinutes?: ?number,
+
+  /**
+   * The date picker text color.
+   */
+  textColor?: ColorValue,
 |}>;
 
 export type AndroidNativeProps = $ReadOnly<{|

--- a/src/types.js
+++ b/src/types.js
@@ -104,7 +104,7 @@ export type IOSNativeProps = $ReadOnly<{|
   /**
    * The date picker text color.
    */
-  textColor?: ColorValue,
+  textColor?: ?number,
 |}>;
 
 export type AndroidNativeProps = $ReadOnly<{|

--- a/src/types.js
+++ b/src/types.js
@@ -104,7 +104,7 @@ export type IOSNativeProps = $ReadOnly<{|
   /**
    * The date picker text color.
    */
-  textColor?: ?number,
+  textColor?: ?ColorValue,
 |}>;
 
 export type AndroidNativeProps = $ReadOnly<{|


### PR DESCRIPTION
# Summary

Add textColor props for iOS datetimepicker (Solves the iOS part of #20)

## Test Plan

![image](https://user-images.githubusercontent.com/4867178/76064579-eba66200-5fc4-11ea-8d98-485be46e30c0.png)

### What's required for testing (prerequisites)?

N/A

### What are the steps to reproduce (after prerequisites)?

N/A

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
