### PR TITLE
throw when invalid props are passed to android picker

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,19 @@ export const DISPLAY_SPINNER = 'spinner';
 export const DISPLAY_CLOCK = 'clock';
 export const DISPLAY_CALENDAR = 'calendar';
 
+// TODO vonovak potentially replace the above string consts with this object
+export const DISPLAY = Object.freeze({
+  spinner: 'spinner',
+  default: 'default',
+  clock: 'clock',
+  calendar: 'calendar',
+});
+
+export const ANDROID_MODE = Object.freeze({
+  date: 'date',
+  time: 'time',
+});
+
 export const DATE_SET_ACTION = 'dateSetAction';
 export const TIME_SET_ACTION = 'timeSetAction';
 export const DISMISS_ACTION = 'dismissedAction';

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -24,7 +24,7 @@ function validateProps(props: AndroidNativeProps) {
   invariant(
     !(display === DISPLAY.calendar && mode === ANDROID_MODE.time) &&
       !(display === DISPLAY.clock && mode === ANDROID_MODE.date),
-    `display: ${display} and mode: ${mode} cannot be used together.`
+    `display: ${display} and mode: ${mode} cannot be used together.`,
   );
 }
 
@@ -98,7 +98,7 @@ export default function RNDateTimePicker(props: AndroidNativeProps) {
     function reject(error) {
       // ignore or throw `activity == null` error
       throw error;
-    }
+    },
   );
 
   return null;

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -10,24 +10,36 @@ import {
   TIME_SET_ACTION,
   DISMISS_ACTION,
   NEUTRAL_BUTTON_ACTION,
+  DISPLAY,
+  ANDROID_MODE,
 } from './constants';
 import pickers from './picker';
 import invariant from 'invariant';
-import React, {Fragment} from 'react';
 
 import type {AndroidEvent, AndroidNativeProps} from './types';
 
-export default function RNDateTimePicker({
-  mode,
-  value,
-  display,
-  onChange,
-  is24Hour,
-  minimumDate,
-  maximumDate,
-  neutralButtonLabel,
-}: AndroidNativeProps) {
+function validateProps(props: AndroidNativeProps) {
+  const {mode, value, display} = props;
   invariant(value, 'A date or time should be specified as `value`.');
+  invariant(
+    !(display === DISPLAY.calendar && mode === ANDROID_MODE.time) &&
+      !(display === DISPLAY.clock && mode === ANDROID_MODE.date),
+    `display: ${display} and mode: ${mode} cannot be used together.`
+  );
+}
+
+export default function RNDateTimePicker(props: AndroidNativeProps) {
+  validateProps(props);
+  const {
+    mode,
+    value,
+    display,
+    onChange,
+    is24Hour,
+    minimumDate,
+    maximumDate,
+    neutralButtonLabel,
+  } = props;
   let picker;
 
   switch (mode) {
@@ -86,10 +98,10 @@ export default function RNDateTimePicker({
     function reject(error) {
       // ignore or throw `activity == null` error
       throw error;
-    },
+    }
   );
 
-  return <Fragment />;
+  return null;
 }
 
 RNDateTimePicker.defaultProps = {

--- a/src/types.js
+++ b/src/types.js
@@ -17,7 +17,7 @@ type Display = $Keys<typeof DISPLAY>;
 export type Event = SyntheticEvent<
   $ReadOnly<{|
     timestamp: number,
-  |}>
+  |}>,
 >;
 
 export type AndroidEvent = {|

--- a/src/types.js
+++ b/src/types.js
@@ -8,15 +8,16 @@ import type {NativeComponent} from 'ReactNative';
 import type {ViewProps} from 'ViewPropTypes';
 import type {ElementRef} from 'react';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
+import {ANDROID_MODE, DISPLAY} from './constants';
 
 type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';
-type AndroidMode = 'date' | 'time';
-type Display = 'spinner' | 'default' | 'clock' | 'calendar';
+type AndroidMode = $Keys<typeof ANDROID_MODE>;
+type Display = $Keys<typeof DISPLAY>;
 
 export type Event = SyntheticEvent<
   $ReadOnly<{|
     timestamp: number,
-  |}>,
+  |}>
 >;
 
 export type AndroidEvent = {|

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,7 +7,9 @@ describe('DatePicker', () => {
   const DATE = 1376949600000;
 
   it('renders a native Component', () => {
-    const tree = renderer.create(<DatePicker value={new Date(DATE)} />).toJSON();
+    const tree = renderer
+      .create(<DatePicker value={new Date(DATE)} />)
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });
@@ -45,13 +47,17 @@ describe('DatePicker', () => {
   });
 
   it('renders with mode `time`', () => {
-    const tree = renderer.create(<DatePicker value={new Date(DATE)} mode="time" />).toJSON();
+    const tree = renderer
+      .create(<DatePicker value={new Date(DATE)} mode="time" />)
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   it('renders with mode `datetime` (iOS only)', () => {
-    const tree = renderer.create(<DatePicker value={new Date(DATE)} mode="datetime" />).toJSON();
+    const tree = renderer
+      .create(<DatePicker value={new Date(DATE)} mode="datetime" />)
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });
@@ -70,15 +76,23 @@ describe('DatePicker', () => {
       {display: 'clock', mode: 'date', value: new Date()},
       'display: clock and mode: date cannot be used together.',
     ],
-  ])('AndroidDateTimePicker throws when invalid props are passed', (props, expected) => {
-    expect(() => AndroidDateTimePicker(props)).toThrow(expected);
-  });
+  ])(
+    'AndroidDateTimePicker throws when invalid props are passed',
+    (props, expected) => {
+      expect(() => AndroidDateTimePicker(props)).toThrow(expected);
+    },
+  );
 
   it('applies styling to DatePicker', () => {
     const style = {backgroundColor: 'red'};
-    const tree = renderer.create(<DatePicker style={style} value={new Date(DATE)} />).toJSON();
+    const tree = renderer
+      .create(<DatePicker style={style} value={new Date(DATE)} />)
+      .toJSON();
 
-    expect(tree).toHaveProperty('props.style', [{height: 216}, {backgroundColor: 'red'}]);
+    expect(tree).toHaveProperty('props.style', [
+      {height: 216},
+      {backgroundColor: 'red'},
+    ]);
     expect(tree).toMatchSnapshot();
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,14 +1,13 @@
 import renderer from 'react-test-renderer';
 import DatePicker from '../src/index.js';
+import AndroidDateTimePicker from '../src/datetimepicker.android';
 import React from 'react';
 
 describe('DatePicker', () => {
   const DATE = 1376949600000;
 
   it('renders a native Component', () => {
-    const tree = renderer
-      .create(<DatePicker value={new Date(DATE)} />)
-      .toJSON();
+    const tree = renderer.create(<DatePicker value={new Date(DATE)} />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });
@@ -46,17 +45,13 @@ describe('DatePicker', () => {
   });
 
   it('renders with mode `time`', () => {
-    const tree = renderer
-      .create(<DatePicker value={new Date(DATE)} mode="time" />)
-      .toJSON();
+    const tree = renderer.create(<DatePicker value={new Date(DATE)} mode="time" />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   it('renders with mode `datetime` (iOS only)', () => {
-    const tree = renderer
-      .create(<DatePicker value={new Date(DATE)} mode="datetime" />)
-      .toJSON();
+    const tree = renderer.create(<DatePicker value={new Date(DATE)} mode="datetime" />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });
@@ -65,16 +60,25 @@ describe('DatePicker', () => {
     expect(new DatePicker()._picker).toBeDefined();
   });
 
+  it.each([
+    [{}, 'A date or time should be specified as `value`.'],
+    [
+      {display: 'calendar', mode: 'time', value: new Date()},
+      'display: calendar and mode: time cannot be used together.',
+    ],
+    [
+      {display: 'clock', mode: 'date', value: new Date()},
+      'display: clock and mode: date cannot be used together.',
+    ],
+  ])('AndroidDateTimePicker throws when invalid props are passed', (props, expected) => {
+    expect(() => AndroidDateTimePicker(props)).toThrow(expected);
+  });
+
   it('applies styling to DatePicker', () => {
     const style = {backgroundColor: 'red'};
-    const tree = renderer
-      .create(<DatePicker style={style} value={new Date(DATE)} />)
-      .toJSON();
+    const tree = renderer.create(<DatePicker style={style} value={new Date(DATE)} />).toJSON();
 
-    expect(tree).toHaveProperty('props.style', [
-      {height: 216},
-      {backgroundColor: 'red'},
-    ]);
+    expect(tree).toHaveProperty('props.style', [{height: 216}, {backgroundColor: 'red'}]);
     expect(tree).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

closes #135 

motivation: android supports different `display` and `mode` props, but not all combinations are possible, eg you cannot pick a time (mode=time) from a calendar (display=calendar).

This will ensure that in such cases we throw an understandable error from JS.


## Test Plan

unit tests were added, tested on device

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
