### PR TITLE
Recommend pod-install for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ yarn add @react-native-community/datetimepicker
 
 #### RN >= 0.60
 
-If you are using RN >= 0.60, only run `pod install` from the ios directory. Then rebuild your project.
+If you are using RN >= 0.60, only run `npx pod-install`. Then rebuild your project.
 
 #### RN < 0.60
 
@@ -80,7 +80,7 @@ For RN < 0.60, you need to link the dependency using `react-native link`:
 react-native link @react-native-community/datetimepicker
 ```
 
-Then run `pod install` from the ios directory and rebuild your project.
+Then run `npx pod-install` and rebuild your project.
 
 If this does not work, see [Manual installation](#manual-installation).
 


### PR DESCRIPTION
# Summary

We've been recommending devs use `npx pod-install` since it will attempt to install CocoaPods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)). This has proved very useful for Expo users who are now migrating to the bare workflow and want to use community packages in their projects.

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`