### PR TITLE
Add Windows as module keyword in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-native",
     "ios",
     "android",
+    "windows",
     "datepicker",
     "timepicker",
     "datetime"


### PR DESCRIPTION
Reflect recent addition of Windows support in module's keyword set - visible in the npm registry. 