### PR TITLE
Change typescript types according the RN 0.62 types on DefinitelyTyped

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 import {FC, Ref, SyntheticEvent} from 'react';
-import {NativeComponent, ViewProps} from 'react-native';
+import {NativeMethods, ViewProps} from 'react-native';
 
 type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';
 type AndroidMode = 'date' | 'time';
@@ -130,7 +130,7 @@ export type DateTimePickerResult = Readonly<{
   minute: number;
 }>;
 
-export type RCTDateTimePickerNative = typeof NativeComponent;
+export type RCTDateTimePickerNative = NativeMethods;
 export type NativeRef = {
   current: Ref<RCTDateTimePickerNative> | null;
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

In the React Native `0.62` the `NativeComponent` was removed and `NativeMethodsMixinStatic` that `NativeComponent const refer` was renamed to `NativeMethods` see this [PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43179/files#diff-054a3bd6f6ba9a4f60119c781c2a63f6)

Closes #195 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

1. git clone https://github.com/salockhart/RNDatePickerError
3. cd DatePickerError
4. `npm install` or `yarn git://github.com/react-native-community/datetimepicker.git#752213fb31c647ae78abbd850a0ec368c715689d`
5. Run tsc

**There should not be TS errors**

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
