### PR TITLE
fix time picker sometimes resets to previous value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # CHANGELOG
 
-- Fix iOS issue where quick value changes would reset the Picker
-
 ### 2.6.0
 
 - Add time picker for Windows [#206](https://github.com/react-native-community/datetimepicker/pull/206)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Fix iOS issue where quick value changes would reset the Picker
+
 ### 2.6.0
 
 - Add time picker for Windows [#206](https://github.com/react-native-community/datetimepicker/pull/206)

--- a/ios/RNDateTimePicker.m
+++ b/ios/RNDateTimePicker.m
@@ -51,4 +51,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   _reactMinuteInterval = minuteInterval;
 }
 
+- (void)setDate:(NSDate *)date {
+    // Need to avoid the case where values coming back through the bridge trigger a new valueChanged event
+    if (![self.date isEqualToDate:date]) {
+        [super setDate:date];
+    }
+}
+
 @end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Keeps values sent to JS side from resetting the native picker component on iOS.
fixes #192

It's a simple diff check on the Class' `setDate:` method

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

See issue above

### What are the steps to reproduce (after prerequisites)?

See issue above

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] ~I added the documentation in `README.md`~
- [x] I mentioned this change in `CHANGELOG.md`
- [ ] ~I updated the typed files (TS and Flow)~
- [ ] ~I added a sample use of the API in the example project (`example/App.js`)~

Let me know if any other info/changes are needed :)
