### PR TITLE
Fix React Native Windows Dependency and Example

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -49,10 +49,12 @@ const ThemedTextInput = (props) => {
 const MODE_VALUES = Platform.select({
   ios: Object.values(IOS_MODE),
   android: Object.values(ANDROID_MODE),
+  windows: [],
 });
 const DISPLAY_VALUES = Platform.select({
   ios: Object.values(IOS_DISPLAY),
   android: Object.values(ANDROID_DISPLAY),
+  windows: [],
 });
 const MINUTE_INTERVALS = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30];
 

--- a/package.json
+++ b/package.json
@@ -69,21 +69,19 @@
     "metro-react-native-babel-preset": "^0.58.0",
     "moment": "^2.24.0",
     "prettier": "^2.0.5",
-    "react": "^16.11.0",
+    "react": "16.11.0",
     "react-native": "^0.62.2",
     "react-native-windows": "^0.62.0-0",
-    "react-test-renderer": "^16.11.0",
+    "react-test-renderer": "16.11.0",
     "semantic-release": "^17.1.1"
   },
   "peerDependencies": {
     "react": ">=16.8.3",
-    "react-native": ">=0.59"
+    "react-native": ">=0.59",
+    "react-native-windows": ">=0.62"
   },
   "dependencies": {
     "invariant": "^2.2.4"
-  },
-  "optionalDependencies": {
-    "react-native-windows": "^0.62.0-0"
   },
   "detox": {
     "test-runner": "jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8427,20 +8427,20 @@ react-refresh@^0.4.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.3.tgz#966f1750c191672e76e16c2efa569150cc73ab53"
   integrity sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==
 
-react-test-renderer@^16.11.0:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
-  integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
+react-test-renderer@16.11.0:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.11.0.tgz#72574566496462c808ac449b0287a4c0a1a7d8f8"
+  integrity sha512-nh9gDl8R4ut+ZNNb2EeKO5VMvTKxwzurbSMuGBoKtjpjbg8JK/u3eVPVNi1h1Ue+eYK9oSzJjb+K3lzLxyA4ag==
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     react-is "^16.8.6"
-    scheduler "^0.19.1"
+    scheduler "^0.17.0"
 
-react@^16.11.0:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+react@16.11.0:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
+  integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -8963,18 +8963,10 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@0.17.0:
+scheduler@0.17.0, scheduler@^0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.17.0.tgz#7c9c673e4ec781fac853927916d1c426b6f3ddfe"
   integrity sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
# Summary

@rectified95 added Windows support to datetime-picker a while back. react-native-windows was added as a peer dependency, but this created warnings in cases where react-native-windows wasn't present in the host app. These warnings are currently present for all community modules with Windows support when RNW isn't installed.

A [follow-up change a few months ago](https://github.com/react-native-community/datetimepicker/commit/feda1770a48489a90f8a9dab73b82ade1c4be468) moved react-native-windows from a peerDependency to an optional dependency. This got rid of the warning but also means that:

- Every user of datetimepicker is now pulling in react-native-windows by default, even if they don't need it
- Due to how it's declared, we now have a transitive peer dependency forcing usage of RN 0.62 instead of RN 0.63
- It will potentially be broken on even react-native-windows 0.62 since we're pulling in multiple RNW versions

This change moves the dependency back to a peer dependency, loosens it to support RNW 0.63, and fixes up a couple of devDependencies that were looser than requested by react-native. I also discovered that a recent change broke the Windows example, and added a quick fix for that.

## Test Plan

Tested running Windows example in repo, and that `yarn --force` doesn't show any new warnings within the repo. This will lead to an ignorable peer dependency warning for projects not including react-native-windows though.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |   ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
